### PR TITLE
wasm: Fix for loops in gaussianBlur fragment shader

### DIFF
--- a/src/imports/designeffects/shaders/gaussianBlur.frag
+++ b/src/imports/designeffects/shaders/gaussianBlur.frag
@@ -24,11 +24,19 @@ vec4 gaussianBlur(sampler2D tex, int miplevel) {
     float k = ceil(blurKernel);
 
     // Normalize kernel weights
-    for (float i = -k; i <= k; ++i) {
+    float i = -k;
+    for(int ii = 0; ii < 10000; ++ii) {
+        if (i > k)
+            break;
         sum += exp(-0.5 * pow(i / sigma, 2.0)) / (sqrtDoublePI * sigma);
+        ++i;
     }
 
-    for (float i = -k; i <= k; ++i) {
+    i = -k;
+    for(int ii = 0; ii < 10000; ++ii) {
+        if (i > k)
+            break;
+
         vec2 coord = qt_TexCoord0 + (pixelSize * float(i));
         float weight = exp(-0.5 * pow(i / sigma, 2.0)) / (sqrtDoublePI * sigma);
 
@@ -39,6 +47,7 @@ vec4 gaussianBlur(sampler2D tex, int miplevel) {
         } else {
             col += texture(tex, coord) * weight / sum;
         }
+        ++i;
     }
 
     return col;


### PR DESCRIPTION
The for loops must have constants like:
  for(int i = 0; i < 100; i += 1)
and not dynamics like:
  for(float i = mini; i <= maxi; i += di)

Fixes: QDS-13685