### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The modules get installed into Qt and provide the respective imports for QML.
 ```
 mkdir build
 cd build
-cmake -GNinja -DCMAKE_INSTALL_PREFIX=path_to_qt_install_directory path_to_qtquickdesigner-components_cmake
+cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=<path_to_qt_install_directory>/lib/cmake/Qt6/qt.toolchain.cmake -DCMAKE_INSTALL_PREFIX=<path_to_qt_install_directory> -DCMAKE_PREFIX_PATH=<path_to_qt_install_directory> -DCMAKE_BUILD_TYPE=<Debug|Release> ..
 cmake --build .
 cmake --install .
 ```


### PR DESCRIPTION
On Windows, with Qt 6.8.1 and latest bundled CMake, following the build instructions resulted in a partial, silently failing build (no DLL's).

When modified as shown here, project built and installed successfully on Windows and Linux.